### PR TITLE
Fix build failures in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+# Prevent missing files (https://github.com/danielparks/matchgen/issues/14).
+# This won’t affect iai output since it puts stuff in matchgen_tests/target. Of
+# course, it might be affected by the bug, but at least that would provide more
+# data about the problem.
+ENV CARGO_TARGET_DIR=/root/target
+
 COPY . /work
 WORKDIR /work
 RUN cargo build --benches --profile bench --all-features


### PR DESCRIPTION
For some reason non-fresh builds in Docker lose files when the `target/` directory is shared with the host machine. This generally results in an error about missing files at the linking step.

This sets `CARGO_TARGET_DIR=/root/target` so that the target directory is not shared with the host.

Works around issue [#14].

[#14]: https://github.com/danielparks/matchgen/issues/14