### PR TITLE
Enable most pedantic clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Added trivial documentation about what errors are returned by a few functions.
+* Disabled [`clippy::single_match_else`] lint (part of [Clippy]’s [pedantic lint
+  group]) within generated match functions, since we sometimes generate `match`
+  statements with a single arm.
+
+[`clippy::single_match_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#single_match_else
+[Clippy]: https://doc.rust-lang.org/stable/clippy/index.html
+[pedantic lint group]: https://doc.rust-lang.org/stable/clippy/usage.html#clippypedantic
+
 ## Release 0.1.0 (2023-02-27)
 
 ### Features

--- a/matchgen_tests/build.rs
+++ b/matchgen_tests/build.rs
@@ -1,3 +1,7 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+
 use matchgen::{Input, TreeMatcher};
 use std::env;
 use std::error::Error;

--- a/matchgen_tests/src/lib.rs
+++ b/matchgen_tests/src/lib.rs
@@ -4,6 +4,12 @@
 //! `tests/` and `benches/` for the actual test code.
 
 #![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+// Not currently compatible with clippy shim.
+#![allow(clippy::must_use_candidate)]
+
+// Not currently compatible with clippy shim.
+// #![warn(missing_docs)]
 
 // Include generated code.
 include!(concat!(env!("OUT_DIR"), "/test-matchers.rs"));


### PR DESCRIPTION
This starts work on ensuring that generated functions will pass even pedantic clippy lints.