### PR TITLE
Add support for setting docs on `TreeMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ All notable changes to this project will be documented in this file.
     functions, since we sometimes generate `match` statements with a single arm.
   * Disabled [`clippy::too_many_lines`] lint within generated match
     functions, since such functions can be extremely long.
+* Added support for setting documentation on generated functions. This also adds
+  docs to the stub function used in disabled Clippy mode which allows it to be
+  used with [`#![warn(missing_docs)]`][missing_docs].
 
 [Clippy]: https://doc.rust-lang.org/stable/clippy/index.html
 [pedantic lint group]: https://doc.rust-lang.org/stable/clippy/usage.html#clippypedantic
 [`#[must_use]`]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
 [`clippy::single_match_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#single_match_else
 [`clippy::too_many_lines`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
+[missing_docs]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.MISSING_DOCS.html
 
 ## Release 0.1.0 (2023-02-27)
 

--- a/matchgen_tests/build.rs
+++ b/matchgen_tests/build.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         // FIXME? I don’t understand why the blank lines cause failures here.
-        .doc(Some(
+        .doc(
             "Match and return `(bool, &[u8])`.
             \n\
             Iterator version.
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Really long doc string to ensure that clippy doesn’t complain even
             though this will have to be will beyond whatever the line length
             limit is.",
-        ))
+        )
         .disable_clippy(true)
         .input_type(Input::Iterator)
         .render(&mut out)?;
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
-        .doc(Some("Match and return `(bool, &[u8])`.\n\nSlice version."))
+        .doc("Match and return `(bool, &[u8])`.\n\nSlice version.")
         .disable_clippy(true)
         .input_type(Input::Slice)
         .render(&mut out)?;
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
-        .doc(Some("Decode basic HTML entities.\n\nIterator version."))
+        .doc("Decode basic HTML entities.\n\nIterator version.")
         .disable_clippy(false)
         .input_type(Input::Iterator)
         .render(&mut out)?;
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
-        .doc(Some("Decode basic HTML entities.\n\nSlice version."))
+        .doc("Decode basic HTML entities.\n\nSlice version.")
         .disable_clippy(false)
         .input_type(Input::Slice)
         .render(&mut out)?;
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut matcher =
         TreeMatcher::new("pub fn most_entity_decode", "&'static str");
     matcher
-        .doc(Some("Decode most HTML entities.\n\nIterator version."))
+        .doc("Decode most HTML entities.\n\nIterator version.")
         .disable_clippy(true)
         .input_type(Input::Iterator)
         .extend(input.iter().map(|(name, info)| {
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     matcher.fn_name = "pub fn most_entity_decode_slice".to_string();
     matcher
-        .doc(Some("Decode most HTML entities.\n\nSlice version."))
+        .doc("Decode most HTML entities.\n\nSlice version.")
         .input_type(Input::Slice)
         .render(&mut out)?;
     writeln!(out)?;

--- a/matchgen_tests/build.rs
+++ b/matchgen_tests/build.rs
@@ -51,57 +51,66 @@ fn main() -> Result<(), Box<dyn Error>> {
         .render_slice(&mut out, "pub fn match_nothing_slice_true", "bool")?;
     writeln!(out)?;
 
-    writeln!(out, "/// Match and return (bool, &[u8]).")?;
     TreeMatcher::new("pub fn slice_in_tuple", "(bool, &'static [u8])")
         .add(b"aab", "(true, &[1, 1])")
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
+        // FIXME? I don’t understand why the blank lines cause failures here.
+        .doc(Some(
+            "Match and return `(bool, &[u8])`.
+            \n\
+            Iterator version.
+            \n\
+            Really long doc string to ensure that clippy doesn’t complain even
+            though this will have to be will beyond whatever the line length
+            limit is.",
+        ))
         .disable_clippy(true)
         .input_type(Input::Iterator)
         .render(&mut out)?;
     writeln!(out)?;
 
-    writeln!(out, "/// Match and return (bool, &[u8]).")?;
     TreeMatcher::new("pub fn slice_in_tuple_slice", "(bool, &'static [u8])")
         .add(b"aab", "(true, &[1, 1])")
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
+        .doc(Some("Match and return `(bool, &[u8])`.\n\nSlice version."))
         .disable_clippy(true)
         .input_type(Input::Slice)
         .render(&mut out)?;
     writeln!(out)?;
 
-    writeln!(out, "/// Decode basic HTML entities.")?;
     TreeMatcher::new("pub fn basic_entity_decode", "u8")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
+        .doc(Some("Decode basic HTML entities.\n\nIterator version."))
         .disable_clippy(false)
         .input_type(Input::Iterator)
         .render(&mut out)?;
     writeln!(out)?;
 
-    writeln!(out, "/// Decode basic HTML entities.")?;
     TreeMatcher::new("pub fn basic_entity_decode_slice", "u8")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
+        .doc(Some("Decode basic HTML entities.\n\nSlice version."))
         .disable_clippy(false)
         .input_type(Input::Slice)
         .render(&mut out)?;
     writeln!(out)?;
 
-    writeln!(out, "/// Decode most HTML entities.")?;
     let input = fs::read("most-html-entities.json")?;
     let input: serde_json::Map<String, serde_json::Value> =
         serde_json::from_slice(&input)?;
     let mut matcher =
         TreeMatcher::new("pub fn most_entity_decode", "&'static str");
     matcher
+        .doc(Some("Decode most HTML entities.\n\nIterator version."))
         .disable_clippy(true)
         .input_type(Input::Iterator)
         .extend(input.iter().map(|(name, info)| {
@@ -113,10 +122,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     matcher.render(&mut out)?;
     writeln!(out)?;
 
-    writeln!(out, "/// Decode most HTML entities.")?;
     matcher.fn_name = "pub fn most_entity_decode_slice".to_string();
-    matcher.input_type(Input::Slice);
-    matcher.render(&mut out)?;
+    matcher
+        .doc(Some("Decode most HTML entities.\n\nSlice version."))
+        .input_type(Input::Slice)
+        .render(&mut out)?;
     writeln!(out)?;
 
     Ok(())

--- a/matchgen_tests/src/lib.rs
+++ b/matchgen_tests/src/lib.rs
@@ -5,9 +5,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
-
-// Not currently compatible with clippy shim.
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 
 // Include generated code.
 include!(concat!(env!("OUT_DIR"), "/test-matchers.rs"));


### PR DESCRIPTION
This also adds docs to the stub function used in disabled Clippy mode which allows it to be used with [`#![warn(missing_docs)]`][warn].

[warn]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.MISSING_DOCS.html