### PR TITLE
Remove `set_` prefix on builder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Breaking changes
+
+* Renamed `TreeMatcher::set_input_type()` to `TreeMatcher::input_type()`.
+
+### Changes
+
 * Made sure generated functions pass [Clippy]’s [pedantic lint group]:
   * Changed to add [`#[must_use]`] to generated functions by default.
   * Added trivial documentation about what errors are returned by a few

--- a/examples/cli-iter.rs
+++ b/examples/cli-iter.rs
@@ -13,6 +13,6 @@ fn main() {
         }
         matcher.add(key_value[0].as_bytes(), format!("{:?}", key_value[1]));
     });
-    matcher.set_input_type(Input::Iterator);
+    matcher.input_type(Input::Iterator);
     matcher.render(&mut io::stdout()).unwrap();
 }

--- a/examples/cli-slice.rs
+++ b/examples/cli-slice.rs
@@ -13,6 +13,6 @@ fn main() {
         }
         matcher.add(key_value[0].as_bytes(), format!("{:?}", key_value[1]));
     });
-    matcher.set_input_type(Input::Slice);
+    matcher.input_type(Input::Slice);
     matcher.render(&mut io::stdout()).unwrap();
 }

--- a/matchgen_tests/build.rs
+++ b/matchgen_tests/build.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         .disable_clippy(true)
-        .set_input_type(Input::Iterator)
+        .input_type(Input::Iterator)
         .render(&mut out)?;
     writeln!(out)?;
 
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         .disable_clippy(true)
-        .set_input_type(Input::Slice)
+        .input_type(Input::Slice)
         .render(&mut out)?;
     writeln!(out)?;
 
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
         .disable_clippy(false)
-        .set_input_type(Input::Iterator)
+        .input_type(Input::Iterator)
         .render(&mut out)?;
     writeln!(out)?;
 
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
         .disable_clippy(false)
-        .set_input_type(Input::Slice)
+        .input_type(Input::Slice)
         .render(&mut out)?;
     writeln!(out)?;
 
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         TreeMatcher::new("pub fn most_entity_decode", "&'static str");
     matcher
         .disable_clippy(true)
-        .set_input_type(Input::Iterator)
+        .input_type(Input::Iterator)
         .extend(input.iter().map(|(name, info)| {
             (
                 name.as_bytes(),
@@ -111,7 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     writeln!(out, "/// Decode most HTML entities.")?;
     matcher.fn_name = "pub fn most_entity_decode_slice".to_string();
-    matcher.set_input_type(Input::Slice);
+    matcher.input_type(Input::Slice);
     matcher.render(&mut out)?;
     writeln!(out)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl TreeMatcher {
     ///
     /// let mut out = Vec::new();
     /// let mut matcher = TreeMatcher::new("fn match_bytes", "u64");
-    /// matcher.set_must_use(false);
+    /// matcher.must_use(false);
     /// matcher.extend([("a".as_bytes(), "1")]);
     /// matcher.render(&mut out).unwrap();
     ///
@@ -172,7 +172,7 @@ impl TreeMatcher {
     ///     out.into_string().unwrap(),
     /// );
     /// ```
-    pub fn set_must_use(&mut self, must_use: bool) -> &mut Self {
+    pub fn must_use(&mut self, must_use: bool) -> &mut Self {
         self.must_use = must_use;
         self
     }
@@ -183,7 +183,7 @@ impl TreeMatcher {
     ///
     ///   * [`Input::Slice`] to accept `&[u8]`
     ///   * [`Input::Iterator`] to accept `core::iter::Iterator<Item = &'a u8>`
-    pub fn set_input_type(&mut self, input_type: Input) -> &mut Self {
+    pub fn input_type(&mut self, input_type: Input) -> &mut Self {
         self.input_type = input_type;
         self
     }


### PR DESCRIPTION
It seems more natural and idiomatic.

This is an API breaking change because it renames `TreeMatcher::set_input_type()` to `TreeMatcher::input_type()`. The other affected method, `TreeMatcher::set_must_use()`, did not exist in the last release.