### PR TITLE
Accept `fmt::Display` instead of `ToString + ?Sized`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes
 
-* Changed `TreeMatcher::new()` to accept `ToString + ?Sized` instead of
-  `AsRef<str>`, since we convert to an owned `String` regardless. This is very
-  unlikely to break anything.
-* Changed `TreeNode::render_iter()` to accept `fmt::Display + ?Sized` instead of
+* Changed `TreeMatcher::new()` to accept `std::fmt::Display` instead of
+  `AsRef<str>`, since we convert to a `String` with `to_string()` regardless.
+  This is very unlikely to break anything.
+* Changed `TreeNode::render_iter()` to accept `std::fmt::Display` instead of
   `AsRef<str>`, since we use the parameters in format strings. This is very
   unlikely to break anything.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,10 @@ impl TreeMatcher {
     /// [`Self::extend()`], then turn it into code with [`Self::render()`].
     ///
     /// See the [struct documentation][TreeMatcher] for a complete example.
-    pub fn new<N, R>(fn_name: &N, return_type: &R) -> Self
+    pub fn new<N, R>(fn_name: N, return_type: R) -> Self
     where
-        N: ToString + ?Sized,
-        R: ToString + ?Sized,
+        N: fmt::Display,
+        R: fmt::Display,
     {
         Self {
             fn_name: fn_name.to_string(),
@@ -672,13 +672,13 @@ impl TreeNode {
     pub fn render_iter<W, N, R>(
         &self,
         writer: &mut W,
-        fn_name: &N,
-        return_type: &R,
+        fn_name: N,
+        return_type: R,
     ) -> io::Result<()>
     where
         W: io::Write,
-        N: fmt::Display + ?Sized,
-        R: fmt::Display + ?Sized,
+        N: fmt::Display,
+        R: fmt::Display,
     {
         let indent = "    "; // Our formatting prevents embedding this.
 
@@ -839,13 +839,13 @@ impl TreeNode {
     pub fn render_slice<W, N, R>(
         &self,
         writer: &mut W,
-        fn_name: &N,
-        return_type: &R,
+        fn_name: N,
+        return_type: R,
     ) -> io::Result<()>
     where
         W: io::Write,
-        N: fmt::Display + ?Sized,
-        R: fmt::Display + ?Sized,
+        N: fmt::Display,
+        R: fmt::Display,
     {
         let indent = "    "; // Our formatting prevents embedding this.
 


### PR DESCRIPTION
This allows the parameter to be passed as borrow or a move.