### PR TITLE
Use cargo-deny to check dependencies

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -43,6 +43,14 @@ jobs:
           tool: cargo-lints
       - run: cargo lints clippy --all-features --all-targets
 
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
   msrv:
     name: cargo msrv
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+[bans]
+multiple-versions = "allow"
+
+[licenses]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MIT",
+  "Unicode-DFS-2016",
+  "Unlicense",
+  "Zlib",
+]
+default = "deny"
+unused-allowed-license = "allow"


### PR DESCRIPTION
This adds a PR check and configuration for [cargo-deny], which verifies that dependencies have acceptable licenses and don’t have outstanding vulnerabilities.

[cargo-deny]: https://github.com/EmbarkStudios/cargo-deny