### PR TITLE
Replace `feature = "cargo-clippy"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   `AsRef<str>`, since we use the parameters in format strings. This is very
   unlikely to break anything.
 
+### Changes
+
+* Switched [code to disable Clippy][disable_clippy] to use `cfg(clippy)` instead
+  of `cfg(feature = "cargo-clippy")`. The [feature has been deprecated].
+
+[disable_clippy]: https://docs.rs/matchgen/latest/matchgen/struct.TreeMatcher.html#method.disable_clippy
+[feature has been deprecated]: https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html
+
 ## Release 0.2.0 (2023-05-26)
 
 This release is primarily aimed at ensuring generated code passes lints.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ impl TreeMatcher {
     ///
     /// use bstr::ByteVec;
     /// pretty_assertions::assert_str_eq!(
-    ///     r#"#[cfg(not(feature = "cargo-clippy"))]
+    ///     r#"#[cfg(not(clippy))]
     /// #[must_use]
     /// fn match_bytes(slice: &[u8]) -> (Option<u64>, &[u8]) {
     ///     match slice.first() {
@@ -370,7 +370,7 @@ impl TreeMatcher {
     ///     }
     /// }
     ///
-    /// #[cfg(feature = "cargo-clippy")]
+    /// #[cfg(clippy)]
     /// #[must_use]
     /// fn match_bytes(slice: &[u8]) -> (Option<u64>, &[u8]) {
     ///     (None, slice)
@@ -385,14 +385,14 @@ impl TreeMatcher {
     /// This can return [`io::Error`] if there is a problem writing to `writer`.
     pub fn render<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         if self.disable_clippy {
-            writeln!(writer, "#[cfg(not(feature = \"cargo-clippy\"))]")?;
+            writeln!(writer, "#[cfg(not(clippy))]")?;
         }
 
         self.render_func(writer)?;
 
         if self.disable_clippy {
             writeln!(writer)?;
-            writeln!(writer, "#[cfg(feature = \"cargo-clippy\")]")?;
+            writeln!(writer, "#[cfg(clippy)]")?;
             self.render_stub(writer)?;
         }
 


### PR DESCRIPTION
`cfg(feature = "cargo-clippy")` has been [deprecated]. The correct way to achieve the same result is now `cfg(clippy)`.

---

Waiting on this work on stable Rust. Currently:

* ❌ Running `cargo clippy` on code that uses `feature = "cargo-clippy"` does not complain.
* ❌ Running `cargo +nightly clippy` on code that uses `feature = "cargo-clippy"` does not complain.
* ❌ `not(cfg(clippy))` does not work on stable clippy — clippy ignores the `cfg` and lints the code.
* ✅ `not(cfg(clippy))` **does** work on nightly clippy — clippy ignores the code.

I’m unsure when any part of this will be stabilized. ([Comment] on the blog post PR.)

[deprecated]: https://github.com/rust-lang/rust-clippy/pull/12292
[Comment]: https://github.com/rust-lang/blog.rust-lang.org/pull/1253#issuecomment-1969734095