### PR TITLE
Fix tests to use local code, not code from crates.io

### DIFF
--- a/matchgen_tests/Cargo.toml
+++ b/matchgen_tests/Cargo.toml
@@ -14,14 +14,14 @@ default = []
 iai = []
 
 [build-dependencies]
-matchgen = "0.2.0"
+matchgen = { path = ".." }
 serde_json = "1.0.91"
 
 [dev-dependencies]
 assert2 = "0.3.7"
 criterion = "0.4.0"
 iai = "0.1.1"
-matchgen = "0.2.0"
+matchgen = { path = ".." }
 paste = "1.0.11"
 
 [lib]


### PR DESCRIPTION
Previously the `matchgen_test` crate specified dependencies on `matchgen` that caused the `matchgen` code to be loaded from `crates.io` rather than just using the local code. This updates the test crate to use the local code.