### PR TITLE
Added `write_to_path()` and `write_to_out_dir()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Added `TreeMatcher::write_to_path()` and `TreeMatcher::write_to_out_dir()` for
+  convenience. This reduces boilerplate needed in build scripts.
+
 ## Release 0.3.0 (2024-06-18)
 
 Once again, this release was cut to ensure generated code passes lints.

--- a/README.md
+++ b/README.md
@@ -33,23 +33,16 @@ like the following:
 
 ```rust
 use matchgen::TreeMatcher;
-use std::env;
 use std::error::Error;
-use std::fs::File;
-use std::io::{BufWriter, Write};
-use std::path::Path;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let out_path = Path::new(&env::var("OUT_DIR")?).join("matcher.rs");
-    let mut out = BufWriter::new(File::create(out_path)?);
-
     TreeMatcher::new("pub fn entity_decode", "u8")
         .doc("Decode basic HTML entities.")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
-        .render(&mut out)?;
+        .write_to_out_dir("matcher.rs")?;
 
     Ok(())
 }


### PR DESCRIPTION
`TreeMatcher::write_to_out_dir()` will save a few lines of boilerplate in a build script.